### PR TITLE
Fixup for federation updates to 6/15

### DIFF
--- a/src/main/scala/HeaderEnum.scala
+++ b/src/main/scala/HeaderEnum.scala
@@ -3,6 +3,7 @@ package testchipip
 import chisel3._
 import chisel3.util.log2Up
 import scala.collection.mutable.{HashMap, ListBuffer}
+import scala.language.postfixOps
 
 class HeaderEnum(val prefix: String) {
   val h = new HashMap[String,Int]

--- a/src/main/scala/TraceIO.scala
+++ b/src/main/scala/TraceIO.scala
@@ -158,13 +158,13 @@ trait CanHaveTraceIO { this: HasTiles =>
   val module: CanHaveTraceIOModuleImp
 
   // Bind all the trace nodes to a BB; we'll use this to generate the IO in the imp
-  val traceNexus = BundleBridgeNexus[Vec[TracedInstruction]]
+  val traceNexus = BundleBridgeNexus[Vec[TracedInstruction]]()
   val tileTraceNodes = tiles.flatMap {
     case ext_tile: WithExtendedTraceport => None
     case tile => Some(tile)
   }.map { _.traceNode }
 
-  val extTraceNexus = BundleBridgeNexus[Vec[ExtendedTracedInstruction]]
+  val extTraceNexus = BundleBridgeNexus[Vec[ExtendedTracedInstruction]]()
   val extTileTraceNodes = tiles.flatMap {
     case ext_tile: WithExtendedTraceport => Some(ext_tile)
     case tile => None


### PR DESCRIPTION
When I bumped federation forward, I encountered the following warnings
and errors and needed to make these changes.  I'd like to ammend this
commit saying Bump to Chisel/Scala/FIRRTL X instead of Federation but I
need someone to help me understand where these came from.

```
[warn] target-design/chipyard/generators/testchipip/src/main/scala/HeaderEnum.scala:10:103: postfix operator mkString should be enabled
[warn] by making the implicit value scala.language.postfixOps visible.
[warn] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[warn] or by setting the compiler option -language:postfixOps.
[warn] See the Scaladoc for value scala.language.postfixOps for a discussion
[warn] why the feature should be explicitly enabled.
[warn]     h.toSeq.sortBy(_._2).map { case (n,i) => s"#define ${prefix.toUpperCase}_${n.toUpperCase} $i\n" } mkString
[warn]                                                                                                       ^
[error] target-design/chipyard/generators/testchipip/src/main/scala/TraceIO.scala:161:37: missing argument list for method apply in object BundleBridgeNexus
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_)(_,_)` instead of `apply`.
[error]   val traceNexus = BundleBridgeNexus[Vec[TracedInstruction]]
[error]                                     ^
[error] target-design/chipyard/generators/testchipip/src/main/scala/TraceIO.scala:167:40: missing argument list for method apply in object BundleBridgeNexus
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `apply _` or `apply(_,_,_)(_,_)` instead of `apply`.
[error]   val extTraceNexus = BundleBridgeNexus[Vec[ExtendedTracedInstruction]]
[error]                                        ^
```